### PR TITLE
Fixed issues related to outdated package name

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -29,7 +29,7 @@ open = (filepath) ->
   else
     dirpath = filepath
   return if not dirpath
-  command = atom.config.get 'open-shell-active-directory.command'
+  command = atom.config.get 'open-bash-git.command'
   require('child_process').exec command, cwd: dirpath, env: filterProcessEnv()
 
 switch require('os').platform()
@@ -47,10 +47,10 @@ module.exports =
       default: defaultCommand
   activate: ->
     atom.commands.add '.tree-view .selected, atom-text-editor, atom-workspace',
-      'open-shell-active-directory:open': (event) ->
+      'open-bash-git:open': (event) ->
         event.stopImmediatePropagation()
         open @getPath?() || @getModel?().getPath?() || getActiveFilePath()
     atom.commands.add 'atom-workspace',
-      'open-shell-active-directory:open-root': (event) ->
+      'open-bash-git:open-root': (event) ->
         event.stopImmediatePropagation()
         open()

--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -1,3 +1,3 @@
 '.platform-darwin atom-workspace':
-  'ctrl-cmd-t': 'open-shell-active-directory:open'
-  'alt-cmd-t': 'open-shell-active-directory:open-root'
+  'ctrl-cmd-t': 'open-bash-git:open'
+  'alt-cmd-t': 'open-bash-git:open-root'

--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -1,3 +1,3 @@
 '.platform-linux atom-workspace':
-  'ctrl-alt-t': 'open-shell-active-directory:open'
-  'ctrl-alt-shift-t': 'open-shell-active-directory:open-root'
+  'ctrl-alt-t': 'open-bash-git:open'
+  'ctrl-alt-shift-t': 'open-bash-git:open-root'

--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -1,3 +1,3 @@
 '.platform-win32 atom-workspace':
-  'ctrl-alt-t': 'open-shell-active-directory:open'
-  'ctrl-alt-shift-t': 'open-shell-active-directory:open-root'
+  'ctrl-alt-t': 'open-bash-git:open'
+  'ctrl-alt-shift-t': 'open-bash-git:open-root'

--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -2,6 +2,6 @@
   '.platform-darwin .tree-view, .platform-darwin atom-text-editor': [
     {
       label: 'Open Shell Here',
-      command: 'open-shell-active-directory:open'
+      command: 'open-bash-git:open'
     }
   ]

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -2,6 +2,6 @@
   '.platform-linux .tree-view, .platform-linux atom-text-editor': [
     {
       label: 'Open Shell Here',
-      command: 'open-shell-active-directory:open'
+      command: 'open-bash-git:open'
     }
   ]

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -2,6 +2,6 @@
   '.platform-win32 .tree-view, .platform-win32 atom-text-editor': [
     {
       label: 'Open Shell Here',
-      command: 'open-shell-active-directory:open'
+      command: 'open-bash-git:open'
     }
   ]

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "Open the Terminal (OSX, Linux) or Git-Bash (Windows) in the given directory via context menu or keyboard shortcut.",
   "activationCommands": {
     ".tree-view .selected, atom-text-editor, atom-workspace": [
-      "open-shell-active-directory:open"
+      "open-bash-git:open"
     ],
     "atom-workspace": [
-      "open-shell-active-directory:open-root"
+      "open-bash-git:open-root"
     ]
   },
   "repository": "https://github.com/Peteous/atom-open-bash-git",


### PR DESCRIPTION
The package name between code and repository were inconsistent and apart from being ugly also broke here:
```
command = atom.config.get 'open-shell-active-directory.command'
```
Should have been
```
command = atom.config.get 'open-bash-git.command'
```